### PR TITLE
fact_bigquery_job_statistics update

### DIFF
--- a/models/marts/fact_bigquery_job_statistics.sql
+++ b/models/marts/fact_bigquery_job_statistics.sql
@@ -66,7 +66,7 @@ with
             , fact_query_metrics.total_slot_processed
         from fact_query_metrics
         left join dim_user on fact_query_metrics.user_id = dim_user.user_id
-        left join dim_query on fact_query_metrics.job_id = dim_query.job_id
+        inner join dim_query on fact_query_metrics.job_id = dim_query.job_id
         left join utils_days on fact_query_metrics.metric_date = utils_days.date_day
     )
 select *


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [X] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and the README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [X] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/_ , feature/_ or patch/\* .
</details>

### What

Given the modeling structure of the fact table, pulling information from `information_schema_jobs` for `job_id`, with the `dim_bigquery_query`, there is a gap in data generation between these two tables that causes `job_id` to be present in the CTE that retrieves from the `information_schema_jobs` and `dim_bigquery_query`, allowing the creation of duplicate` metrics_sk` and null `query_fk`. Therefore, the proposed solution is to change the `left join` to an `inner join` so that only the `job_id` common to both tables are brought in.

### Why

Avoid duplicated `metrics_sk` and nulls `query_fk`.

### Known limitations

N/A